### PR TITLE
Added fluid compatibility and converted the xp storage to use a liquid amount. 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx6G
 	archives_base_name = xp_obelisk
 
 #Fabric api
-	fabric_version=0.47.10+1.18.2
+	fabric_version=0.50.0+1.18.2
 
 
 

--- a/src/main/java/com/notker/xp_storage/XpFunctions.java
+++ b/src/main/java/com/notker/xp_storage/XpFunctions.java
@@ -74,7 +74,7 @@ public final class XpFunctions {
     }
 
     public static TranslatableText xp_to_text(StorageBlockEntity tile) {
-        return xp_to_text(tile.containerExperience);
+        return xp_to_text((int)tile.liquidXp.amount / 810);
     }
 
     public static TranslatableText xp_to_text(int value) {

--- a/src/main/java/com/notker/xp_storage/XpStorageClient.java
+++ b/src/main/java/com/notker/xp_storage/XpStorageClient.java
@@ -39,12 +39,12 @@ public class XpStorageClient implements ClientModInitializer {
             registry.register(new Identifier("xps:blocks/xp_flow"));
         });
 
-        FluidRenderHandlerRegistry.INSTANCE.register(ModFluids.STILL_XP, ModFluids.FLOWING_XP, new SimpleFluidRenderHandler(
+        FluidRenderHandlerRegistry.INSTANCE.register(ModFluids.LIQUID_XP, ModFluids.LIQUID_XP_FLOWING, new SimpleFluidRenderHandler(
                 new Identifier("xps:blocks/xp_still"),
                 new Identifier("xps:blocks/xp_flow"),
                 0xCCFF00
         ));
 
-        BlockRenderLayerMap.INSTANCE.putFluids(RenderLayer.getTranslucent(), ModFluids.STILL_XP, ModFluids.FLOWING_XP);
+        BlockRenderLayerMap.INSTANCE.putFluids(RenderLayer.getTranslucent(), ModFluids.LIQUID_XP, ModFluids.LIQUID_XP_FLOWING);
     }
 }

--- a/src/main/java/com/notker/xp_storage/blocks/StorageBlockEntity.java
+++ b/src/main/java/com/notker/xp_storage/blocks/StorageBlockEntity.java
@@ -1,26 +1,21 @@
 package com.notker.xp_storage.blocks;
 
-import com.notker.xp_storage.XpStorage;
-import com.notker.xp_storage.fluids.LiquidXP;
 import com.notker.xp_storage.regestry.ModBlocks;
 import com.notker.xp_storage.regestry.ModFluids;
-import net.fabricmc.fabric.api.transfer.v1.fluid.FluidConstants;
-import net.fabricmc.fabric.api.transfer.v1.fluid.FluidStorage;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+import net.fabricmc.fabric.api.transfer.v1.storage.StoragePreconditions;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleVariantStorage;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.entity.ExperienceOrbEntity;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.Packet;
 import net.minecraft.network.listener.ClientPlayPacketListener;
 import net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket;
+import net.minecraft.tag.TagKey;
 import net.minecraft.text.Text;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Direction;
-import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
@@ -28,7 +23,6 @@ import java.util.UUID;
 @SuppressWarnings("UnstableApiUsage")
 public class StorageBlockEntity extends BlockEntity {
 
-    public int containerExperience = 0;
     public UUID player_uuid = Util.NIL_UUID;
     public Text playerName = Text.of("");
 
@@ -48,26 +42,46 @@ public class StorageBlockEntity extends BlockEntity {
         }
 
         @Override
+        public long insert(FluidVariant insertedVariant, long maxAmount, TransactionContext transaction) {
+            StoragePreconditions.notBlankNotNegative(insertedVariant, maxAmount);
+            if (canInsert(insertedVariant)) {
+                long insertedAmount = Math.min(maxAmount, getCapacity(insertedVariant) - amount);
+
+                if (insertedAmount > 0) {
+                    updateSnapshots(transaction);
+
+                    if (variant.isBlank()) {
+                        variant = FluidVariant.of(ModFluids.LIQUID_XP);
+                        amount = insertedAmount;
+                    } else {
+                        amount += insertedAmount;
+                    }
+                }
+
+                return insertedAmount;
+            }
+
+            return 0;
+        }
+
+        @Override
         protected boolean canInsert(FluidVariant variant) {
-            return variant.equals(FluidVariant.of(ModFluids.LIQUID_XP));
+            var variant_name = variant.getFluid().getDefaultState().getBlockState().toString();
+            return variant_name.contains("liquid_xp") || variant_name.contains("xp_fluid");
         }
 
         @Override
         protected boolean canExtract(FluidVariant variant) {
-            return variant.equals(FluidVariant.of(ModFluids.LIQUID_XP));
+            var variant_name = variant.getFluid().getDefaultState().getBlockState().toString();
+            return variant_name.contains("liquid_xp") || variant_name.contains("xp_fluid");
         }
 
         @Override
         protected void onFinalCommit() {
-            containerExperience = (int)(liquidXp.amount / 810);
             markDirty();
             toUpdatePacket();
         }
     };
-
-    public static <E extends BlockEntity> void tick(World world1, BlockPos pos, BlockState state1, StorageBlockEntity entity) {
-
-    }
 
     public void setUuidAndNameTo() {
         setUuidAndNameTo(Util.NIL_UUID, Text.of(""));
@@ -80,33 +94,16 @@ public class StorageBlockEntity extends BlockEntity {
         this.toUpdatePacket();
     }
 
-    public int getAvailableContainerSpace() {
-        return Integer.MAX_VALUE - this.containerExperience;
-    }
-
     public String getContainerFillPercentage() {
-        float container_progress = (100.0f / Integer.MAX_VALUE) * this.containerExperience;
+        float container_progress = (100.0f / Integer.MAX_VALUE) * (this.liquidXp.amount-810);
         return String.format(java.util.Locale.US,"%.7f", container_progress) + "%";
-    }
-
-    /**
-     * Prevents Integer overflow on XP insert
-     */
-    public void addXpToContainer(int xpToAdd) {
-        if (this.getAvailableContainerSpace() > xpToAdd) {
-            this.containerExperience += xpToAdd;
-        } else {
-            this.containerExperience = Integer.MAX_VALUE;
-        }
-
-        this.markDirty();
-        this.toUpdatePacket();
     }
 
     @Override
     public void writeNbt(NbtCompound tag) {
         super.writeNbt(tag);
-        tag.putInt("containerExperience", this.containerExperience);
+        tag.put("fluidVariant", liquidXp.variant.toNbt());
+        tag.putLong("amount", liquidXp.amount);
         tag.putUuid("player_uuid", this.player_uuid);
         tag.putString("playerName", this.playerName.asString());
         writeIdToNbt(tag, ModBlocks.STORAGE_BLOCK_ENTITY);
@@ -114,28 +111,26 @@ public class StorageBlockEntity extends BlockEntity {
         if (world != null) {
             world.updateListeners(pos, getCachedState(), getCachedState(), net.minecraft.block.Block.NOTIFY_ALL);
         }
-
-
     }
 
     @Override
     public void readNbt(NbtCompound tag) {
         super.readNbt(tag);
-        this.containerExperience = tag.getInt("containerExperience");
+        liquidXp.variant = FluidVariant.fromNbt(tag.getCompound("fluidVariant"));
+        liquidXp.amount = tag.getLong("amount");
         this.player_uuid = tag.getUuid("player_uuid");
         this.playerName = Text.of(tag.getString("playerName"));
     }
 
     public NbtCompound getNbtData() {
         NbtCompound stackTag = new NbtCompound();
-        stackTag.putInt("containerExperience", this.containerExperience);
         stackTag.putUuid("player_uuid", this.player_uuid);
         stackTag.putString("playerName", this.playerName.asString());
         return stackTag;
     }
 
     public int getContainerExperience() {
-        return containerExperience;
+        return (int)(this.liquidXp.amount / 810);
     }
 
     @Nullable

--- a/src/main/java/com/notker/xp_storage/blocks/StorageBlockEntity.java
+++ b/src/main/java/com/notker/xp_storage/blocks/StorageBlockEntity.java
@@ -1,8 +1,17 @@
 package com.notker.xp_storage.blocks;
 
+import com.notker.xp_storage.XpStorage;
+import com.notker.xp_storage.fluids.LiquidXP;
 import com.notker.xp_storage.regestry.ModBlocks;
+import com.notker.xp_storage.regestry.ModFluids;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidConstants;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidStorage;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleVariantStorage;
+import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.entity.ExperienceOrbEntity;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.Packet;
 import net.minecraft.network.listener.ClientPlayPacketListener;
@@ -10,21 +19,54 @@ import net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket;
 import net.minecraft.text.Text;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
+@SuppressWarnings("UnstableApiUsage")
 public class StorageBlockEntity extends BlockEntity {
 
     public int containerExperience = 0;
     public UUID player_uuid = Util.NIL_UUID;
     public Text playerName = Text.of("");
 
-
-
     public StorageBlockEntity(BlockPos pos, BlockState state) {
-
         super(ModBlocks.STORAGE_BLOCK_ENTITY, pos, state);
+    }
+
+    public final SingleVariantStorage<FluidVariant> liquidXp = new SingleVariantStorage<FluidVariant>() {
+        @Override
+        protected FluidVariant getBlankVariant() {
+            return FluidVariant.blank();
+        }
+
+        @Override
+        protected long getCapacity(FluidVariant variant) {
+            return Integer.MAX_VALUE;
+        }
+
+        @Override
+        protected boolean canInsert(FluidVariant variant) {
+            return variant.equals(FluidVariant.of(ModFluids.LIQUID_XP));
+        }
+
+        @Override
+        protected boolean canExtract(FluidVariant variant) {
+            return variant.equals(FluidVariant.of(ModFluids.LIQUID_XP));
+        }
+
+        @Override
+        protected void onFinalCommit() {
+            containerExperience = (int)(liquidXp.amount / 810);
+            markDirty();
+            toUpdatePacket();
+        }
+    };
+
+    public static <E extends BlockEntity> void tick(World world1, BlockPos pos, BlockState state1, StorageBlockEntity entity) {
+
     }
 
     public void setUuidAndNameTo() {
@@ -75,7 +117,6 @@ public class StorageBlockEntity extends BlockEntity {
 
 
     }
-
 
     @Override
     public void readNbt(NbtCompound tag) {

--- a/src/main/java/com/notker/xp_storage/fluids/LiquidXP.java
+++ b/src/main/java/com/notker/xp_storage/fluids/LiquidXP.java
@@ -8,12 +8,12 @@ import net.minecraft.item.Item;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.Properties;
 
-public class Xp_fluid extends Xp_fluid_abstract{
+public class LiquidXP extends LiquidXPAbstract {
     public static int XpPerBucket = 100;
 
     @Override
     public Fluid getStill() {
-        return ModFluids.STILL_XP;
+        return ModFluids.LIQUID_XP;
     }
 
     @Override
@@ -23,7 +23,7 @@ public class Xp_fluid extends Xp_fluid_abstract{
 
     @Override
     public Fluid getFlowing() {
-        return ModFluids.FLOWING_XP;
+        return ModFluids.LIQUID_XP_FLOWING;
     }
 
     @Override
@@ -41,7 +41,7 @@ public class Xp_fluid extends Xp_fluid_abstract{
         return false;
     }
 
-    public static class Flowing extends Xp_fluid {
+    public static class Flowing extends LiquidXP {
         @Override
         protected void appendProperties(StateManager.Builder<Fluid, FluidState> builder) {
             super.appendProperties(builder);
@@ -59,7 +59,7 @@ public class Xp_fluid extends Xp_fluid_abstract{
         }
     }
 
-    public static class Still extends Xp_fluid {
+    public static class Still extends LiquidXP {
         @Override
         public int getLevel(FluidState fluidState) {
             return 8;

--- a/src/main/java/com/notker/xp_storage/fluids/LiquidXPAbstract.java
+++ b/src/main/java/com/notker/xp_storage/fluids/LiquidXPAbstract.java
@@ -12,7 +12,7 @@ import net.minecraft.world.BlockView;
 import net.minecraft.world.WorldAccess;
 import net.minecraft.world.WorldView;
 
-public abstract class Xp_fluid_abstract extends FlowableFluid {
+public abstract class LiquidXPAbstract extends FlowableFluid {
     /**
      * @return whether the given fluid an instance of this fluid
      */

--- a/src/main/java/com/notker/xp_storage/regestry/ModBlocks.java
+++ b/src/main/java/com/notker/xp_storage/regestry/ModBlocks.java
@@ -5,6 +5,7 @@ import com.notker.xp_storage.blocks.StorageBlock;
 import com.notker.xp_storage.blocks.StorageBlockEntity;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidStorage;
 import net.minecraft.block.Material;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.sound.BlockSoundGroup;
@@ -22,13 +23,16 @@ public class ModBlocks {
 
 
     public static final String TAG_ID = "BlockEntityTag";
-
-
     public static final BlockEntityType<StorageBlockEntity> STORAGE_BLOCK_ENTITY = FabricBlockEntityTypeBuilder.create(StorageBlockEntity::new, BLOCK_XP_OBELISK).build(null);
-
     public static void registerBlocks() {
         Registry.register(Registry.BLOCK, new Identifier(XpStorage.MOD_ID, "block_xp_obelisk"), BLOCK_XP_OBELISK);
 
         Registry.register(Registry.BLOCK_ENTITY_TYPE, new Identifier(XpStorage.MOD_ID, "entity_xp_obelisk"), STORAGE_BLOCK_ENTITY);
+        BlockEntityType<StorageBlockEntity> STORAGE = null;
+//        FluidStorage.SIDED.registerForBlockEntity((storage, direction) -> switch (direction) {
+//            case DOWN -> storage.liquidXp;
+//            default -> null;
+//        }, STORAGE_BLOCK_ENTITY);
+        FluidStorage.SIDED.registerForBlockEntity((storage, direction) -> storage.liquidXp, STORAGE_BLOCK_ENTITY);
     }
 }

--- a/src/main/java/com/notker/xp_storage/regestry/ModFluids.java
+++ b/src/main/java/com/notker/xp_storage/regestry/ModFluids.java
@@ -1,7 +1,8 @@
 package com.notker.xp_storage.regestry;
 
 import com.notker.xp_storage.XpStorage;
-import com.notker.xp_storage.fluids.Xp_fluid;
+import com.notker.xp_storage.fluids.LiquidXP;
+import com.notker.xp_storage.fluids.LiquidXP;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.minecraft.block.Block;
 import net.minecraft.block.FluidBlock;
@@ -15,17 +16,17 @@ import net.minecraft.util.registry.Registry;
 
 public class ModFluids {
 
-    public static FlowableFluid STILL_XP;
-    public static FlowableFluid FLOWING_XP;
+    public static FlowableFluid LIQUID_XP;
+    public static FlowableFluid LIQUID_XP_FLOWING;
     public static Item XP_BUCKET;
     public static Block XP_FLUID;
 
     public static void registerFluids() {
-        STILL_XP = Registry.register(Registry.FLUID, new Identifier(XpStorage.MOD_ID, "xp_fluid"), new Xp_fluid.Still());
-        FLOWING_XP = Registry.register(Registry.FLUID, new Identifier(XpStorage.MOD_ID, "flowing_xp"), new Xp_fluid.Flowing());
+        LIQUID_XP = Registry.register(Registry.FLUID, new Identifier(XpStorage.MOD_ID, "xp_fluid"), new LiquidXP.Still());
+        LIQUID_XP_FLOWING = Registry.register(Registry.FLUID, new Identifier(XpStorage.MOD_ID, "flowing_xp"), new LiquidXP.Flowing());
         XP_BUCKET = Registry.register(Registry.ITEM, new Identifier(XpStorage.MOD_ID, "xp_bucket"),
-                new BucketItem(STILL_XP, new Item.Settings().recipeRemainder(Items.BUCKET).maxCount(1)));
-        XP_FLUID = Registry.register(Registry.BLOCK, new Identifier(XpStorage.MOD_ID, "xp_fluid"), new FluidBlock(STILL_XP, FabricBlockSettings
+                new BucketItem(LIQUID_XP, new Item.Settings().recipeRemainder(Items.BUCKET).maxCount(1)));
+        XP_FLUID = Registry.register(Registry.BLOCK, new Identifier(XpStorage.MOD_ID, "xp_fluid"), new FluidBlock(LIQUID_XP, FabricBlockSettings
                 .of(Material.LAVA)
                 .noCollision()
                 .luminance(10)


### PR DESCRIPTION
Using the transfer API to add/remove "xp" should allow for more validation and prevent any potential dupe issue that might have happened. 